### PR TITLE
fix dead player position conflict bug

### DIFF
--- a/games/a/pommerman/envs/v0.py
+++ b/games/a/pommerman/envs/v0.py
@@ -276,7 +276,7 @@ class Pomme(gym.Env):
                     # The agent made an invalid direction.
                     agent.stop()
             else:
-                next_positions.append(None)
+                next_positions[agent.agent_id] = None
 
         counter = make_counter(next_positions)
         while has_position_conflict(counter):

--- a/games/train_with_tensorforce.py
+++ b/games/train_with_tensorforce.py
@@ -3,7 +3,7 @@
 Call this with a config, a game, and a list of agents, one of which should be a tensorforce agent. The script will start separate threads to operate the agents and then report back the result.
 
 An example with all three simple agents running ffa:
-python run_battle.py --agents=tensorforce::ppo,a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent --config=ffa_v0
+python train_with_tensorforce.py --agents=tensorforce::ppo,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent --config=ffa_v0
 """
 import a
 


### PR DESCRIPTION
This fixes a bug where a dead player creates an invisible wall.

The code was trying to set the agent's `next_position` to `None`, so that it wouldn't register in the position conflict checking, but instead it was _appending_ `None` to `next_positions`.  This caused dead agents to always create position conflicts at their death spot.

It was a one-line fix.