### PR TITLE
Serialize game state into json

### DIFF
--- a/games/a/pommerman/characters.py
+++ b/games/a/pommerman/characters.py
@@ -53,12 +53,12 @@ class Agent(object):
     def set_start_position(self, start_position):
         self.start_position = start_position
 
-    def reset(self):
+    def reset(self, ammo=1, is_alive=True, blast_strength=utility.DEFAULT_BLAST_STRENGTH, can_kick=False):
         self.position = self.start_position
-        self.ammo = 1
-        self.is_alive = True
-        self.blast_strength = utility.DEFAULT_BLAST_STRENGTH
-        self.can_kick = False
+        self.ammo = ammo
+        self.is_alive = is_alive
+        self.blast_strength = blast_strength
+        self.can_kick = can_kick
 
     def pick_up(self, item):
         if item == utility.Item.ExtraBomb:
@@ -77,16 +77,24 @@ class Agent(object):
                 self.blast_strength += 2
                 self.blast_strength = min(self.blast_strength, 10)
 
+    def to_json(self):
+        return {"agent_id": self.agent_id,
+                "is_alive": self.is_alive,
+                "position": self.position,
+                "ammo": self.ammo,
+                "blast_strength": self.blast_strength,
+                "can_kick": self.can_kick}
+
 
 class Bomb(object):
     """Container for the Bomb object."""
 
-    def __init__(self, bomber, position, life, blast_strength):
+    def __init__(self, bomber, position, life, blast_strength, moving_direction = None):
         self.bomber = bomber
         self.position = position
         self._life = life
         self.blast_strength = blast_strength
-        self.moving_direction = None
+        self.moving_direction = moving_direction
 
     def tick(self):
         self._life -= 1
@@ -118,17 +126,28 @@ class Bomb(object):
     def is_moving(self):
         return self.moving_direction is not None
 
+    def to_json(self):
+        return {"position": self.position,
+                "bomber_id": self.bomber.agent_id,
+                "life": self._life,
+                "blast_strength": self.blast_strength,
+                "moving_direction": self.moving_direction}
+
 
 class Flame(object):
     """Container for Flame object."""
 
-    def __init__(self, position):
+    def __init__(self, position, life = 2):
         self.position = position
-        self._life = 2
+        self._life = life
 
     def tick(self):
         self._life -= 1
 
     def is_dead(self):
         return self._life == 0
+
+    def to_json(self):
+        return {"position": self.position,
+                "life": self._life}
 

--- a/games/a/pommerman/envs/utility.py
+++ b/games/a/pommerman/envs/utility.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from enum import Enum
 import itertools
 import random
+import numpy
+import json
 
 import numpy as np
 
@@ -317,12 +319,18 @@ def get_next_position(position, direction):
 def make_np_float(feature):
     return np.array(feature).astype(np.float32)
 
-
 def to_json(obj):
-    """Converts the given object into a json representable structure."""
-    try:
-        return json.dumps(obj)
-    except TypeError:
-        # TODO
-        return None
+    return json.dumps(obj, default=serializer)
+
+def serializer(obj):
+    if isinstance(obj, numpy.ndarray):
+        return obj.tolist()
+    elif isinstance(obj, numpy.int64):
+        return int(obj)
+    elif hasattr(obj, 'to_json'):
+        return obj.to_json()
+    elif hasattr(obj, '__dict__'):
+        return obj.__dict__
+
+    return obj
 

--- a/games/a/pommerman/envs/v0.py
+++ b/games/a/pommerman/envs/v0.py
@@ -78,6 +78,14 @@ class Pomme(gym.Env):
         self.training_agent = agent_id
 
     def set_init_game_state(self, game_state_file):
+        # game_state_file JSON format expected:
+        # - list of agents serialized (agent_id, is_alive, position, ammo, blast_strength, can_kick)
+        # - board matrix topology (board_size^2)
+        # - board size
+        # - list of bombs serialized (position, bomber_id, life, blast_strength, moving_direction)
+        # - list of flames serialized (position, life)
+        # - list of item by position
+        # - step count
         self._init_game_state = None
         if game_state_file:
             with open(game_state_file, 'r') as f:

--- a/games/a/pommerman/envs/v0.py
+++ b/games/a/pommerman/envs/v0.py
@@ -433,11 +433,6 @@ class Pomme(gym.Env):
                 self._viewer = None
             return
 
-        if record_pngs_dir and not os.path.isdir(record_pngs_dir):
-            os.makedirs(record_pngs_dir)
-        if record_json_dir and not os.path.isdir(record_json_dir):
-            os.makedirs(record_json_dir)
-
         human_factor = utility.HUMAN_FACTOR
         frames = self._render_frames()
         if mode == 'rgb_array':
@@ -505,7 +500,7 @@ class Pomme(gym.Env):
                 'agents': utility.to_json(self._agents),
                 'bombs': utility.to_json(self._bombs),
                 'flames': utility.to_json(self._flames),
-                'items': utility.to_json(str(self._items))
+                'items': utility.to_json([[k, i] for k,i in self._items.items()])
             }
 
         return ret
@@ -521,7 +516,10 @@ class Pomme(gym.Env):
             for y in range(self._board_size):
                 self._board[x,y] = boardArray[x][y]
 
-        self._items = eval(json.loads(self._init_game_state['items']))
+        self._items = {}
+        itemArray = json.loads(self._init_game_state['items'])
+        for i in itemArray:
+            self._items[tuple(i[0])] = i[1]
 
         agentArray = json.loads(self._init_game_state['agents'])
         for a in agentArray:
@@ -533,10 +531,10 @@ class Pomme(gym.Env):
         bombArray = json.loads(self._init_game_state['bombs'])
         for b in bombArray:
             bomber = next(x for x in self._agents if x.agent_id == b['bomber_id'])
-            self._bombs.append(Bomb(bomber, (b['position'][0], b['position'][1]), b['life'], b['blast_strength'], b['moving_direction']))
+            self._bombs.append(Bomb(bomber, tuple(b['position']), b['life'], b['blast_strength'], b['moving_direction']))
 
         self._flames = []
         flameArray = json.loads(self._init_game_state['flames'])
         for f in flameArray:
-            self._flames.append(Flame((f['position'][0], f['position'][1]), f['life']))
+            self._flames.append(Flame(tuple(f['position']), f['life']))
         

--- a/games/run_battle.py
+++ b/games/run_battle.py
@@ -97,6 +97,13 @@ if __name__ == "__main__":
 
     atexit.register(functools.partial(clean_up_agents, _agents))
 
+    if args.record_pngs_dir:
+        assert not os.path.isdir(args.record_pngs_dir)
+        os.makedirs(args.record_pngs_dir)
+    if args.record_json_dir:
+        assert not os.path.isdir(args.record_json_dir)
+        os.makedirs(args.record_json_dir)
+
     print("Starting the Game.")
     obs = env.reset()
     steps = 0


### PR DESCRIPTION
Serialize game state into human readable JSON.
The save is gametype/agent agnostic, to be able to reload a board with a different setup.

**Record game example:**
python run_battle.py --agents=test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent --config=ffa_v0 --record_json_dir=./jsons

**Replay game from step 50 example:**
python run_battle.py --agents=test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent,test::a.pommerman.agents.SimpleAgent --config=ffa_v0 --game_state_file=./jsons/50.json
