### PR TITLE
Multiplayer mode!

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -44,6 +44,11 @@ An example with one player, two random agents, and one test agent:
 $ pom_battle --agents=player::arrows,test::agents.SimpleAgent,random::null,random::null --config=ffa_v0
 ```
 
+A two-player, two-agent game:
+```
+$ pom_battle --agents=player::arrows,player::wasd,test::agents.SimpleAgent,test::agents.SimpleAgent --config=ffa_v0
+```
+
 ### Closing the environment
 You can close the virtual environment using this command
 ```$ deactivate```

--- a/pommerman/__init__.py
+++ b/pommerman/__init__.py
@@ -29,10 +29,7 @@ def make_agent(config_string, agent_string, agent_id=-1, docker_env_dict=None):
     assert agent_type in ["player", "random", "docker", "test"]
 
     if agent_type == "player":
-        assert agent_control in ["arrows"]
-        on_key_press, on_key_release = utility.get_key_control(agent_control)
-        agent_instance = agents.PlayerAgent(
-            agent, utility.KEY_INPUT, on_key_press=on_key_press, on_key_release=on_key_release)
+        agent_instance = agents.PlayerAgent(agent, agent_control)
     elif agent_type == "random":
         agent_instance = agents.RandomAgent(agent)
     elif agent_type == "docker":

--- a/pommerman/agents/base_agent.py
+++ b/pommerman/agents/base_agent.py
@@ -12,7 +12,7 @@ class BaseAgent:
         raise NotImplementedError()
 
     @staticmethod
-    def has_key_input():
+    def has_user_input():
         return False
 
     def shutdown(self):

--- a/pommerman/agents/player_agent.py
+++ b/pommerman/agents/player_agent.py
@@ -8,24 +8,37 @@ class PlayerAgent(BaseAgent):
     def __init__(self, agent, control):
         super(PlayerAgent, self).__init__(agent)
         self._key_input = {'curr': 0}
-        assert control == 'arrows', 'No input besides "arrows" implemented yet.'
+
+        if control == 'arrows':
+            self._key2act = {
+                key.UP: 1,
+                key.DOWN: 2,
+                key.LEFT: 3,
+                key.RIGHT: 4,
+                key.SPACE: 5,
+                key.M: 6 # In Pommerman, this will freeze the game.
+            }
+        elif control == 'wasd':
+            self._key2act = {
+                key.W: 1,
+                key.S: 2,
+                key.A: 3,
+                key.D: 4,
+                key.E: 5,
+                key.Q: 6 # In Pommerman, this will freeze the game.
+            }
+        else:
+            raise ValueError("Unknown player control '{}'".format(control))
 
     def act(self, obs, action_space):
         return self._key_input['curr']
 
     @staticmethod
-    def has_key_input():
+    def has_user_input():
         return True
 
     def on_key_press(self, k, mod):
-        self._key_input['curr'] = {
-            key.UP: 1,
-            key.DOWN: 2,
-            key.LEFT: 3,
-            key.RIGHT: 4,
-            key.SPACE: 5,
-            key.A: 6 # In Pommerman, this will freeze the game.
-        }.get(k, 0)
+        self._key_input['curr'] = self._key2act.get(k, 0)
 
     def on_key_release(self, k, mod):
         self._key_input['curr'] = 0

--- a/pommerman/agents/player_agent.py
+++ b/pommerman/agents/player_agent.py
@@ -1,13 +1,14 @@
+from pyglet.window import key
+
 from . import BaseAgent
 
 
 class PlayerAgent(BaseAgent):
     """The Player Agent that lets the user control a character."""
-    def __init__(self, agent, key_input, on_key_press, on_key_release):
-        self._agent = agent
-        self._key_input = key_input
-        self.on_key_press = on_key_press
-        self.on_key_release = on_key_release
+    def __init__(self, agent, control):
+        super(PlayerAgent, self).__init__(agent)
+        self._key_input = {'curr': 0}
+        assert control == 'arrows', 'No input besides "arrows" implemented yet.'
 
     def act(self, obs, action_space):
         return self._key_input['curr']
@@ -15,3 +16,16 @@ class PlayerAgent(BaseAgent):
     @staticmethod
     def has_key_input():
         return True
+
+    def on_key_press(self, k, mod):
+        self._key_input['curr'] = {
+            key.UP: 1,
+            key.DOWN: 2,
+            key.LEFT: 3,
+            key.RIGHT: 4,
+            key.SPACE: 5,
+            key.A: 6 # In Pommerman, this will freeze the game.
+        }.get(k, 0)
+
+    def on_key_release(self, k, mod):
+        self._key_input['curr'] = 0

--- a/pommerman/cli/train_with_tensorforce.py
+++ b/pommerman/cli/train_with_tensorforce.py
@@ -25,7 +25,7 @@ def clean_up_agents(agents):
     return [agent.shutdown() for agent in agents]
 
 
-class WrappedEnv(OpenAIGym):    
+class WrappedEnv(OpenAIGym):
     def __init__(self, gym, visualize=False):
         self.gym = gym
         self.visualize = visualize
@@ -70,10 +70,7 @@ def main():
         agent_type, agent_control = agent_info.split("::")
         assert agent_type in ["player", "random", "docker", "test", "tensorforce"]
         if agent_type == "player":
-            assert agent_control in ["arrows"]
-            on_key_press, on_key_release = utility.get_key_control(agent_control)
-            agent = agents.PlayerAgent(
-                agent, utility.KEY_INPUT, on_key_press=on_key_press, on_key_release=on_key_release)
+            agent = agents.PlayerAgent(agent, agent_control)
         elif agent_type == "random":
             agent = agents.RandomAgent(agent)
         elif agent_type == "docker":

--- a/pommerman/utility.py
+++ b/pommerman/utility.py
@@ -13,46 +13,6 @@ import ruamel.yaml as yaml
 from .envs import utility
 
 
-class KeyInput(Enum):
-    NULL = 0
-    UP = 1
-    DOWN = 2
-    LEFT = 3
-    RIGHT = 4
-    SPACE = 5
-
-KEY_INPUT = {'curr': 0}
-def get_key_control(ty):
-    """Key Control for use with the player controlling the character.
-
-    Args:
-      ty: The string declaring which set of keys you want to use. Options: ["arrows"].
-
-    Returns:
-      on_key_press: The key press action.
-      on_key_release: The key release action.
-    """
-    from pyglet.window import key
-
-    def on_key_press(k, mod):
-        global KEY_INPUT
-        if ty == 'arrows':
-            KEY_INPUT['curr'] = {
-                key.UP: 1,
-                key.DOWN: 2,
-                key.LEFT: 3,
-                key.RIGHT: 4,
-                key.SPACE: 5,
-                key.A: 6 # In Pommerman, this will freeze the game.
-            }.get(k, 0)
-
-    def on_key_release(k, mod):
-        global KEY_INPUT
-        KEY_INPUT['curr'] = 0
-
-    return on_key_press, on_key_release
-
-
 def random_string(num_chars):
     return ''.join(random.choice(string.ascii_lowercase) for _ in range(num_chars))
 


### PR DESCRIPTION
First commit slightly refactors the code, moving input-control code from `utility.py` to `player_agent`. I think that's more proper anyways.

The second commit makes use of that change in order to allow same-screen multiplayer mode :smile: Just have two agents as `player::arrows,player::wasd` and give it a try! Also updated the `GettingStarted.md` accordingly.

Supersedes #38, close #38.