### PR TITLE
Implement more natural human player input.

### DIFF
--- a/pommerman/agents/player_agent.py
+++ b/pommerman/agents/player_agent.py
@@ -1,5 +1,64 @@
+"""
+NOTE:
+
+There are a few minor complications to fluid human control which make this
+code a little more involved than trivial.
+
+1. Key press-release cycles can be, and often are, faster than one tick of
+   the game/simulation, but the player still wants that cycle to count, i.e.
+   to lay a bomb!
+2. When holding down a key, the player expects that action to be repeated,
+   at least after a slight delay.
+3. But when holding a key down (say, move left) and simultaneously doing a
+   quick press-release cycle (put a bomb), we want the held-down key to keep
+   being executed, but the cycle should have happened in-between.
+
+The way we solve this problem is by separating key-state and actions-to-do.
+We hold the actions that need be executed in a queue (`self._action_q`) and
+a state for all considered keys.
+
+1. When a key is pressed down, we note the time and mark it as down.
+2. If it is released quickly thereafter, before a game tick could happen,
+   we add its action into the queue. This often happens when putting bombs.
+3. If it's still pressed down as we enter a game tick, we do some math to see
+   if it's time for a "repeat" event and, if so, push an action to the queue.
+4. Just work off one item from the queue each tick.
+
+This way, the input is "natural" and things like dropping a bomb while doing
+a diagonal walk from one end to the other "just work".
+"""
+
+from time import time
+
 from . import BaseAgent
 from .. import characters
+
+
+REPEAT_DELAY = 0.2  # seconds
+REPEAT_INTERVAL = 0.1
+
+class Keystate:
+    def __init__(self):
+        self.keydown_time = time()
+        self.last_repeat_time = None
+        self.fired = False
+
+    def should_fire(self):
+        if self.last_repeat_time is None:
+            # The first repetition:
+            if time() - self.keydown_time > REPEAT_DELAY:
+                return True
+        else:
+            # A repetition after the first:
+            if time() - self.last_repeat_time > REPEAT_INTERVAL:
+                return True
+
+        # No repetition yet
+        return False
+
+    def mark_fired(self):
+        self.last_repeat_time = time()
+        self.fired = True
 
 
 class PlayerAgent(BaseAgent):
@@ -14,7 +73,7 @@ class PlayerAgent(BaseAgent):
         # and prevents Pommerman from running.
         #
         from pyglet.window import key
-        self._controls = {
+        CONTROLS = {
             'arrows': {
                 key.UP: 1,
                 key.DOWN: 2,
@@ -33,19 +92,40 @@ class PlayerAgent(BaseAgent):
             }
         }
 
-        assert agent_control in self._controls.keys()
-        self._key_input = {'curr': 0}
-        self._control_type = agent_control
+        assert agent_control in CONTROLS, "Unknown control: {}".format(agent_control)
+        self._key2act = CONTROLS[agent_control]
+
+        self._action_q = []
+        self._keystate = {}
 
     def act(self, obs, action_space):
-        return self._key_input['curr']
+        # Go through the keys and fire for those that needs repetition (because they're held down)
+        for k, state in self._keystate.items():
+            if state.should_fire():
+                self._action_q.append(k)
+                state.mark_fired()
+
+        act = 0
+        if self._action_q:  # Work off the keys that are queued.
+            act = self._key2act[self._action_q.pop(0)]
+        return act
 
     @staticmethod
     def has_user_input():
         return True
 
     def on_key_press(self, k, mod):
-        self._key_input['curr'] = self._controls[self._control_type].get(k, 0)
+        # Ignore if we're not handling the key. Avoids "shadowing" ticks in
+        # multiplayer mode.
+        if k in self._key2act:
+            self._keystate[k] = Keystate()
 
     def on_key_release(self, k, mod):
-        self._key_input['curr'] = 0
+        # We only need to act on keys for which we did something in the
+        # `key_press` event, and ignore any other key releases.
+        if k in self._keystate:
+            # Only mark this as a "press" upon release if it was a quick one,
+            # i.e. not held down and executed already
+            if not self._keystate[k].fired:
+                self._action_q.append(k)
+            del self._keystate[k]


### PR DESCRIPTION
The comment on top should describe both the problem of the current approach, as well as the new proposed approach, so I won't repeat it here. Code is extensively commented as otherwise it looks needlessly over-engineered, but it isn't.

The magic numbers used (`0.2` and `0.1`) are what I remember using in past games, but could be tweaked. For example, my linux uses `0.66` and `0.025` (check yours using `xset q | grep 'auto repeat delay'`) but I felt it was too delayed for a game.

Getting user input feel "natural" is actually nontrivial (I know from experience) and super-simple code almost never feels right. I know it wasn't a priority for this project, but it felt frustrating play-testing it and losing to `SimpleAgent` because of input issues, not skill. With this patch, I'm still losing regularly, but at least now it feels like I'm losing because of my poor skill :smile: I also play-tested it in multiplayer with my wife and it works nice.

Note that this PR comments-out the pause action since it crashes the game (as noted marked in a comment before my changes already) and we hit it several times by accident during play. I can undo that and leave it in if you prefer.