### PR TITLE
Partially fix run_battle.py, which broke in #40.

### DIFF
--- a/pommerman/__init__.py
+++ b/pommerman/__init__.py
@@ -25,7 +25,8 @@ _register()
 
 
 def make(config_id, agent_list, game_state_file=None):
-    assert config_id in registry
+    assert config_id in registry, "Unknown configuration '{}'. " \
+        "Possible values: {}".format(config_id, registry)
     env = gym.make(config_id)
 
     for id, agent in enumerate(agent_list):

--- a/pommerman/cli/run_battle.py
+++ b/pommerman/cli/run_battle.py
@@ -20,18 +20,25 @@ import time
 import argparse
 import numpy as np
 
+from .. import helpers
 from .. import make
 
 
 def run(args, num_times=1, seed=None):
     config = args.config
-    agents_string = args.agents
     record_pngs_dir = args.record_pngs_dir
     record_json_dir = args.record_json_dir
     agent_env_vars = args.agent_env_vars
     game_state_file = args.game_state_file
 
-    env = make(config, agents_string, agent_env_vars, game_state_file)
+    # TODO: After https://github.com/MultiAgentLearning/playground/pull/40
+    #       this is still missing the docker_env_dict parsing for the agents.
+    agents = [
+        helpers._make_agent_from_string(agent_string, agent_id+1000)
+        for agent_id, agent_string in enumerate(args.agents.split(','))
+    ]
+
+    env = make(config, agents, game_state_file)
 
     if args.record_pngs_dir:
         assert not os.path.isdir(args.record_pngs_dir)


### PR DESCRIPTION
What this is still missing, is the parsing of docker env variables to be
passed to the agent. It's missing, because I have no clue about that and
so wouldn't even know how to test my attempt at fixing it :smile:

(The problem is the change in `make` interface but missing adaptation of `run_battle.py` as I mention [here](https://github.com/MultiAgentLearning/playground/pull/40#issuecomment-376984803))