### PR TITLE
"Fix" the pause code (missing import).

### DIFF
--- a/pommerman/envs/utility.py
+++ b/pommerman/envs/utility.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from enum import Enum
 import itertools
 import random
+import time
 
 import numpy as np
 
@@ -60,7 +61,7 @@ class Action(Enum):
     Left = 3
     Right = 4
     Bomb = 5
-    Pause = 6 # This pauses the game for 5 seconds.
+    Pause = 6 # This pauses the game for 5 minutes.
 
 
 class Result(Enum):
@@ -222,10 +223,10 @@ def is_valid_direction(board, position, direction, invalid_values=None):
 
     if Action(direction) == Action.Up:
         return row - 1 >= 0 and board[row-1][col] not in invalid_values
-    
+
     if Action(direction) == Action.Down:
         return row + 1 < len(board) and board[row+1][col] not in invalid_values
-    
+
     if Action(direction) == Action.Left:
         return col - 1 >= 0 and board[row][col-1] not in invalid_values
 


### PR DESCRIPTION
"Fix" in quotes because I still think that's not a real pause functionality :smile: 

I looked into turning it into a real pause, that can be unpaused. That's actually not trivial in the current codebase. The more I think about it, the less I believe this should be an actual action that an agent makes!

1. You don't really want the agent to learn about pause/unpause, do you? So it's not part of the agent's formal action space, but [currently it kinda is](https://github.com/MultiAgentLearning/playground/blob/master/pommerman/envs/v0.py#L60).

2. Since the pause can only be triggered by a human player's key-press, I believe you only want to use this pause from humans, right? In that case, pausing/unpausing should be part of the human user-interface, not of the agent or forward model. So I think a separate (agent-independent) handler should be registered [around here](https://github.com/MultiAgentLearning/playground/blob/master/pommerman/envs/v0.py#L234).

But I don't see the value in the added complexity of such a "real pause" functionality, it's not like you can drop into an interactive python shell when pausing and inspect things, so I won't spend more time on it myself, sorry.