### PR TITLE
Tensorforce: fix agent training

### DIFF
--- a/pommerman/cli/train_with_tensorforce.py
+++ b/pommerman/cli/train_with_tensorforce.py
@@ -68,7 +68,6 @@ class WrappedEnv(OpenAIGym):
         all_actions.insert(self.gym.training_agent, actions)
         state, reward, terminal, _ = self.gym.step(all_actions)
         agent_state = featurize(state[self.gym.training_agent])
-
         agent_reward = reward[self.gym.training_agent]
         return agent_state, terminal, agent_reward
 


### PR DESCRIPTION
When trying to train a tensorforce agent,
`pom_tf_battle  --agents=test::agents.SimpleAgent,test::agents.SimpleAgent,test::agents.SimpleAgent,tensorforce::ppo --config=PommeFFAFast-v0`
I received the following error:
```
Traceback (most recent call last):
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/bin/pom_tf_battle", line 11, in <module>
    load_entry_point('pommerman==0.2.0', 'console_scripts', 'pom_tf_battle')()
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/pommerman/cli/train_with_tensorforce.py", line 120, in main
    runner.run(episodes=10, max_episode_timesteps=2000)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorforce/execution/runner.py", line 100, in run
    action = self.agent.act(states=state, deterministic=deterministic)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorforce/agents/agent.py", line 197, in act
    independent=independent
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorforce/models/model.py", line 1207, in act
    fetch_list = self.monitored_session.run(fetches=fetches, feed_dict=feed_dict)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/training/monitored_session.py", line 546, in run
    run_metadata=run_metadata)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/training/monitored_session.py", line 1113, in run
    raise six.reraise(*original_exc_info)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/six.py", line 693, in reraise
    raise value
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/training/monitored_session.py", line 1098, in run
    return self._sess.run(*args, **kwargs)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/training/monitored_session.py", line 1170, in run
    run_metadata=run_metadata)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/training/monitored_session.py", line 950, in run
    return self._sess.run(*args, **kwargs)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 905, in run
    run_metadata_ptr)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1116, in _run
    str(subfeed_t.get_shape())))
ValueError: Cannot feed value of shape (1, 516) for Tensor 'ppo/state-state:0', which has shape '(?, 519)'
```

After updating the file with the code from the [notebook](https://github.com/MultiAgentLearning/playground/blob/master/notebooks/Playground.ipynb), received the following error:

```
Traceback (most recent call last):
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/bin/pom_tf_battle", line 11, in <module>
    load_entry_point('pommerman==0.2.0', 'console_scripts', 'pom_tf_battle')()
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/pommerman/cli/train_with_tensorforce.py", line 153, in main
    runner.run(episodes=10, max_episode_timesteps=2000)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/tensorforce/execution/runner.py", line 104, in run
    state, terminal, step_reward = self.environment.execute(actions=action)
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/pommerman/cli/train_with_tensorforce.py", line 69, in execute
    all_actions.insert(self.gym.training_agent, actions)
TypeError: 'TensorForceAgent' object cannot be interpreted as an integer
Exception ignored in: <bound method SimpleImageViewer.__del__ of <gym.envs.classic_control.rendering.SimpleImageViewer object at 0x11fb37630>>
Traceback (most recent call last):
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/gym/envs/classic_control/rendering.py", line 347, in __del__
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/gym/envs/classic_control/rendering.py", line 343, in close
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/pyglet/window/cocoa/__init__.py", line 281, in close
  File "/Users/jhaygood1271/Documents/schoo/playground/venv/lib/python3.6/site-packages/pyglet/window/__init__.py", line 770, in close
ImportError: sys.meta_path is None, Python is likely shutting down
```

which lead me to update this line: `env.set_training_agent(agent.agent_id)`