### PR TITLE
correcting my last pull request to fix --render flag when it's false

### DIFF
--- a/pommerman/cli/train_with_tensorforce.py
+++ b/pommerman/cli/train_with_tensorforce.py
@@ -126,7 +126,7 @@ def main():
 
     atexit.register(functools.partial(clean_up_agents, agents))
     wrapped_env = WrappedEnv(env, visualize=args.render)
-    runner = Runner(agent=agent, environment=wrapped_env)
+    wrapped_env = WrappedEnv(env, visualize=(args.render==True))
     runner.run(episodes=10, max_episode_timesteps=2000)
     print("Stats: ", runner.episode_rewards, runner.episode_timesteps,
           runner.episode_times)

--- a/pommerman/cli/train_with_tensorforce.py
+++ b/pommerman/cli/train_with_tensorforce.py
@@ -125,8 +125,8 @@ def main():
     agent = training_agent.initialize(env)
 
     atexit.register(functools.partial(clean_up_agents, agents))
-    wrapped_env = WrappedEnv(env, visualize=args.render)
     wrapped_env = WrappedEnv(env, visualize=(args.render==True))
+    runner = Runner(agent=agent, environment=wrapped_env)
     runner.run(episodes=10, max_episode_timesteps=2000)
     print("Stats: ", runner.episode_rewards, runner.episode_timesteps,
           runner.episode_times)


### PR DESCRIPTION
Hi,
first I'm sorry for the last pull request I somehow replaced the wrong line.
So I was trying to train a tensorforce agent with --render=False but it didn't work.
It turned out to be that it's read as a string inside the train_with_tensorforce.py and renders the env whether --render=False or True by default so I corrected the bug.