### PR TITLE
fixing --render argument

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -38,7 +38,7 @@ To get a list of active options you can run `pom_battle --help`. Below is a list
 
 - `--record_json_dir` defines the directory to record the JSON representations of the game. The default is `None`. If the directory doesn't exist, it will be created.
 
-- `--render` allows you to turn of rendering of the game. The default is `True`.
+- `--render` allows you to turn of rendering of the game. The default is `False`.
 
 - `--render_mode` changes the render mode of the game. The default is `human`. Available options are `human`, `rgb_pixel`, and `rgb_array`.
 

--- a/pommerman/cli/run_battle.py
+++ b/pommerman/cli/run_battle.py
@@ -129,9 +129,10 @@ def main():
                         default=None,
                         help='Directory to record the JSON representations of '
                         "the game. Doesn't record if None.")
-    parser.add_argument('--render',
-                        default=True,
-                        help="Whether to render or not. Defaults to True.")
+    parser.add_argument("--render",
+                        default=False,
+                        action='store_true',
+                        help="Whether to render or not. Defaults to False.")
     parser.add_argument('--render_mode',
                         default='human',
                         help="What mode to render. Options are human, rgb_pixel, and rgb_array")

--- a/pommerman/cli/train_with_tensorforce.py
+++ b/pommerman/cli/train_with_tensorforce.py
@@ -84,8 +84,9 @@ def main():
                         help="Directory to record the JSON representations of "
                         "the game. Doesn't record if None.")
     parser.add_argument("--render",
-                        default=True,
-                        help="Whether to render or not. Defaults to True.")
+                        default=False,
+                        action='store_true',
+                        help="Whether to render or not. Defaults to False.")
     parser.add_argument("--game_state_file",
                         default=None,
                         help="File from which to load game state. Defaults to "


### PR DESCRIPTION
Now the game is not rendered by default and rendering is enabled via adding --render.