### PR TITLE
Fixed small bug in example_ffa_run

### DIFF
--- a/examples/simple_ffa_run.py
+++ b/examples/simple_ffa_run.py
@@ -9,7 +9,7 @@ def main():
        Use this as an example to set up your training env.
     '''
     # Print all possible environments in the Pommerman registry
-    print(pommerman.registry)
+    print(pommerman.REGISTRY)
 
     # Create a set of agents (exactly four)
     agent_list = [


### PR DESCRIPTION
The global variable in pommerman is called "REGISTRY", instead of "registry", which causes the example to crash.