### PR TITLE
#133 (Multiple flames at same position - bomb movement/expl.)

### DIFF
--- a/pommerman/forward_model.py
+++ b/pommerman/forward_model.py
@@ -149,6 +149,13 @@ class ForwardModel(object):
                 flames.append(flame)
         curr_flames = flames
 
+        # Redraw all current flames
+        # Multiple flames may share a position and the map should contain
+        # a flame until all flames are dead to avoid issues with bomb
+        # movements and explosions.
+        for flame in curr_flames:
+            curr_board[flame.position] = constants.Item.Flames.value
+
         # Step the living agents and moving bombs.
         # If two agents try to go to the same spot, they should bounce back to
         # their previous spots. This is complicated with one example being when


### PR DESCRIPTION
#133 
When a flame dies it may reveal an item at the beginning of the step function.
If another flame at the same position is still alive it will replace the item on the board with a flame towards the end of the step function.
Between revealing the item on the board and replacing it with a flame the item will be visible to the bomb movement logic and will prevent the bomb from moving into the flame.

A similar issue when no item is revealed causes bombs to be able to move into a flame without exploding.

Just redraw all flames after all dead flames are handled.