### PR TITLE
Fix minor debugging warning on Windows

### DIFF
--- a/pommerman/__init__.py
+++ b/pommerman/__init__.py
@@ -8,6 +8,7 @@ from . import forward_model
 from . import helpers
 from . import utility
 
+gym.logger.set_level(40)
 REGISTRY = None
 
 


### PR DESCRIPTION
`gym` outputs `?[33mWARN: gym.spaces.Box autodetected dtype as <class 'numpy.float32'>. Please provide explicit dtype.?[0m` on Windows whenever it's imported. This fixes it by lowering the debug level.