### PR TITLE
Add http agent and fix agent helper. (#42)

### DIFF
--- a/pommerman/agents/__init__.py
+++ b/pommerman/agents/__init__.py
@@ -1,6 +1,7 @@
 '''Entry point into the agents module set'''
 from .base_agent import BaseAgent
 from .docker_agent import DockerAgent
+from .http_agent import HttpAgent
 from .player_agent import PlayerAgent
 from .random_agent import RandomAgent
 from .simple_agent import SimpleAgent

--- a/pommerman/agents/http_agent.py
+++ b/pommerman/agents/http_agent.py
@@ -1,0 +1,80 @@
+'''The HTTP agent - provides observation using http push to remote
+   agent and expects action in the reply'''
+import json
+import time
+import os
+import threading
+import requests
+
+from . import BaseAgent
+from .. import utility
+from .. import characters
+
+
+class HttpAgent(BaseAgent):
+    """The HTTP Agent that connects to a port with a remote agent where the
+       character runs. It uses the same interface as the docker agent and
+       is useful for debugging."""
+
+    def __init__(self,
+                 port=8080,
+                 host='localhost',
+                 timeout=120,
+                 character=characters.Bomber):
+        self._port = port
+        self._host = host
+        self._timeout = timeout
+        super(HttpAgent, self).__init__(character)
+        self._wait_for_remote()
+
+    def _wait_for_remote(self):
+        """Wait for network service to appear. A timeout of 0 waits forever."""
+        timeout = self._timeout
+        backoff = .25
+        max_backoff = min(timeout, 16)
+
+        if timeout:
+            # time module is needed to calc timeout shared between two exceptions
+            end = time.time() + timeout
+
+        while True:
+            try:
+                now = time.time()
+                if timeout and end < now:
+                    print("Timed out - %s:%s" % (self._host, self._port))
+                    raise
+
+                request_url = 'http://%s:%s/ping' % (self._host, self._port)
+                req = requests.get(request_url)
+                self._acknowledged = True
+                return True
+            except requests.exceptions.ConnectionError as e:
+                print("ConnectionError: ", e)
+                backoff = min(max_backoff, backoff * 2)
+                time.sleep(backoff)
+            except requests.exceptions.HTTPError as e:
+                print("HTTPError: ", e)
+                backoff = min(max_backoff, backoff * 2)
+                time.sleep(backoff)
+
+    def act(self, obs, action_space):
+        obs_serialized = json.dumps(obs, cls=utility.PommermanJSONEncoder)
+        request_url = "http://{}:{}/action".format(self._host, self._port)
+        try:
+            req = requests.post(
+                request_url,
+                timeout=0.15,
+                json={
+                    "obs":
+                    obs_serialized,
+                    "action_space":
+                    json.dumps(action_space, cls=utility.PommermanJSONEncoder)
+                })
+            action = req.json()['action']
+        except requests.exceptions.Timeout as e:
+            print('Timeout!')
+            # TODO: Fix this. It's ugly.
+            action = [0] * len(action_space.shape)
+            if len(action) == 1:
+                action = action[0]
+        return action

--- a/pommerman/helpers/__init__.py
+++ b/pommerman/helpers/__init__.py
@@ -13,12 +13,14 @@ def make_agent_from_string(agent_string, agent_id, docker_env_dict=None):
     
     agent_type, agent_control = agent_string.split("::")
 
-    assert agent_type in ["player", "random", "docker", "test", "tensorforce"]
+    assert agent_type in ["player", "simple", "random", "docker", "http" , "test", "tensorforce"]
 
     agent_instance = None
 
     if agent_type == "player":
         agent_instance = agents.PlayerAgent(agent_control=agent_control)
+    elif agent_type == "simple":
+        agent_instance = agents.SimpleAgent()
     elif agent_type == "random":
         agent_instance = agents.RandomAgent()
     elif agent_type == "docker":
@@ -30,6 +32,9 @@ def make_agent_from_string(agent_string, agent_id, docker_env_dict=None):
         assert port is not None
         agent_instance = agents.DockerAgent(
             agent_control, port=port, server=server, env_vars=docker_env_dict)
+    elif agent_type == "http":
+        host, port = agent_control.split(":")
+        agent_instance = agents.HttpAgent(port=port, host=host)
     elif agent_type == "test":
         agent_instance = eval(agent_control)()
     elif agent_type == "tensorforce":


### PR DESCRIPTION
Example http agent usage:

 pom_battle --agents simple::null,simple::null,http::localhost:8085,simple::null --render

PR is mostly a  copy & paste from docker agent and some fixes for broken agent selection CLI.
Would be nice to use it as a base for the docker agent to avoid duplicated code - but don't really have the time.