### PR TITLE
Choosing IDLE action crashed when agent timeouted.

### DIFF
--- a/pommerman/agents/docker_agent.py
+++ b/pommerman/agents/docker_agent.py
@@ -139,9 +139,11 @@ class DockerAgent(BaseAgent):
         except requests.exceptions.Timeout as e:
             print('Timeout!')
             # TODO: Fix this. It's ugly.
-            action = [0] * len(action_space.shape)
-            if len(action) == 1:
-                action = action[0]
+            num_actions = len(action_space.shape)
+            if num_actions > 1:
+                return [0] * num_actions
+            else:
+                return 0
         return action
 
     def episode_end(self, reward):

--- a/pommerman/agents/http_agent.py
+++ b/pommerman/agents/http_agent.py
@@ -88,9 +88,11 @@ class HttpAgent(BaseAgent):
         except requests.exceptions.Timeout as e:
             print('Timeout!')
             # TODO: Fix this. It's ugly.
-            action = [0] * len(action_space.shape)
-            if len(action) == 1:
-                action = action[0]
+            num_actions = len(action_space.shape)
+            if num_actions > 1:
+                return [0] * num_actions
+            else:
+                return 0
         return action
 
     def episode_end(self, reward):


### PR DESCRIPTION
My understanding is that len(action_space.shape) is zero, so action is
empty. This solution works, but may not be the most beautiful either.