### PR TITLE
Fixed train_with_tensorflow.py errors

### DIFF
--- a/pommerman/cli/train_with_tensorforce.py
+++ b/pommerman/cli/train_with_tensorforce.py
@@ -19,8 +19,8 @@ from tensorforce.execution import Runner
 from tensorforce.contrib.openai_gym import OpenAIGym
 import gym
 
-from .. import helpers, make
-from ..agents import TensorForceAgent
+from pommerman import helpers, make
+from pommerman.agents import TensorForceAgent
 
 
 CLIENT = docker.from_env()
@@ -32,15 +32,18 @@ def clean_up_agents(agents):
 
 
 class WrappedEnv(OpenAIGym):
-    '''An Env Wrapper used to make it easier to work 
+    '''An Env Wrapper used to make it easier to work
     with multiple agents'''
+
     def __init__(self, gym, visualize=False):
         self.gym = gym
         self.visualize = visualize
 
-    def execute(self, actions):
+    def execute(self, action):
         if self.visualize:
             self.gym.render()
+
+        actions = self.unflatten_action(action=action)
 
         obs = self.gym.get_observations()
         all_actions = self.gym.act(obs)


### PR DESCRIPTION
When running the train_with_tensorforce.py script as-
```
python3 train_with_tensorforce.py --agents=tensorforce::ppo,test::agents.SimpleAgent,test::agents.SimpleAgent,test::agents.SimpleAgent  --config=PommeFFACompetition-v0 --render
```
I face two issues-

**Relative Imports**
The relative imports produce an error on my machine:
```
Traceback (most recent call last):
  File "train_with_tensorforce.py", line 22, in <module>
    from .. import helpers, make
ValueError: attempted relative import beyond top-level package
```
This is the same error as described here- #83

Adding absolute imports as described [here](https://github.com/MultiAgentLearning/playground/issues/83#issuecomment-390128736) fixes it.

**Actions not being unflattened**
After fixing the imports, I still received an error-
```
Traceback (most recent call last):
  File "train_with_tensorforce.py", line 153, in <module>
    main()
  File "train_with_tensorforce.py", line 142, in main
    runner.run(episodes=10, max_episode_timesteps=2000)
  File "/home/nihal111/.local/lib/python3.6/site-packages/tensorforce/execution/runner.py", line 104, in run
    state, terminal, step_reward = self.environment.execute(action=action)
TypeError: execute() got an unexpected keyword argument 'action'
```
Looking at the [notebook](https://github.com/MultiAgentLearning/playground/blob/master/notebooks/Playground.ipynb) that appears to do the same thing, I understand that the execute method inside the WrappedEnv class is defined in a different way. The following line was missing in `train_with_tensorforce.py`-

```
actions = self.unflatten_action(action=action)
```

This PR fixes both of these issues on my machine. Hope this helps.