### PR TITLE
Fixes 115: Added blocking keyboard player (squashed commits)

### DIFF
--- a/pommerman/agents/__init__.py
+++ b/pommerman/agents/__init__.py
@@ -3,6 +3,7 @@ from .base_agent import BaseAgent
 from .docker_agent import DockerAgent
 from .http_agent import HttpAgent
 from .player_agent import PlayerAgent
+from .player_agent_blocking import PlayerAgentBlocking
 from .random_agent import RandomAgent
 from .simple_agent import SimpleAgent
 from .tensorforce_agent import TensorForceAgent

--- a/pommerman/agents/player_agent_blocking.py
+++ b/pommerman/agents/player_agent_blocking.py
@@ -1,0 +1,44 @@
+"""
+This variant is blocking, that is the game pauses for keyboard input.
+"""
+
+from time import time
+import click
+
+from . import BaseAgent
+from .. import characters
+from .. import constants
+
+# keypad control codes
+K_PREFIX = '\x1b'
+K_RT = '[C'
+K_LF = '[D'
+K_UP = '[A'
+K_DN = '[B'
+
+
+class PlayerAgentBlocking(BaseAgent):
+    """Block for keyboard input."""
+
+    def __init__(self, character=characters.Bomber, agent_control='arrows'):
+        super(PlayerAgentBlocking, self).__init__(character)
+        self.agent_control = agent_control
+
+    def act(self, obs, action_space):
+        key = click.getchar()
+        if self.agent_control == 'arrows':
+            if key == K_RT + K_PREFIX: return constants.Action.Right.value
+            if key == K_LF + K_PREFIX: return constants.Action.Left.value
+            if key == K_UP + K_PREFIX: return constants.Action.Up.value
+            if key == K_DN + K_PREFIX: return constants.Action.Down.value
+            if key == ' ': return constants.Action.Bomb.value
+            return constants.Action.Stop.value
+
+        if self.agent_control == 'wasd':
+            if key == 'd': return constants.Action.Right.value
+            if key == 'a': return constants.Action.Left.value
+            if key == 'w': return constants.Action.Up.value
+            if key == 's': return constants.Action.Down.value
+            if key == 'e': return constants.Action.Bomb.value
+            if key == 'q': return constants.Action.Stop.value
+            return constants.Action.Stop.value

--- a/pommerman/helpers/__init__.py
+++ b/pommerman/helpers/__init__.py
@@ -13,12 +13,14 @@ def make_agent_from_string(agent_string, agent_id, docker_env_dict=None):
     
     agent_type, agent_control = agent_string.split("::")
 
-    assert agent_type in ["player", "simple", "random", "docker", "http" , "test", "tensorforce"]
+    assert agent_type in ["player", "playerblock", "simple", "random", "docker", "http" , "test", "tensorforce"]
 
     agent_instance = None
 
     if agent_type == "player":
         agent_instance = agents.PlayerAgent(agent_control=agent_control)
+    elif agent_type == "playerblock":
+        agent_instance = agents.PlayerAgentBlocking(agent_control=agent_control)
     elif agent_type == "simple":
         agent_instance = agents.SimpleAgent()
     elif agent_type == "random":

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ websockets~=6.0
 websocket-client~=0.53.0
 python-cli-ui~=0.7.1
 python-rapidjson~=0.6.3
+Click==7.0


### PR DESCRIPTION
Same as https://github.com/MultiAgentLearning/playground/pull/206/ but:
- ran yapf on pommerman/agents/player_agent_blocking.py
- squashed to 1 commit
