### PR TITLE
replace scipy resize by PIL

### DIFF
--- a/pommerman/graphics.py
+++ b/pommerman/graphics.py
@@ -11,7 +11,7 @@ from time import strftime
 
 from gym.utils import reraise
 import numpy as np
-from scipy.misc import imresize as resize
+from PIL import Image
 
 try:
     import pyglet
@@ -156,15 +156,13 @@ class PixelViewer(Viewer):
                                    self._is_partially_observable,
                                    self._agent_view_size)
 
-        all_img = resize(
-            rgb_array[0],
-            (board_size * human_factor, board_size * human_factor),
-            interp='nearest')
+        all_img = np.array(Image.fromarray(rgb_array[0].astype(np.uint8)).resize(
+            (board_size * human_factor, board_size * human_factor), resample=Image.NEAREST))
         other_imgs = [
-            resize(
-                frame, (int(board_size * human_factor / len(self._agents)),
-                        int(board_size * human_factor / len(self._agents))),
-                interp='nearest') for frame in rgb_array[1:]
+            np.array(Image.fromarray(frame.astype(np.uint8)).resize(
+                (int(board_size * human_factor / len(self._agents)),
+                 int(board_size * human_factor / len(self._agents))),
+                resample=Image.NEAREST)) for frame in rgb_array[1:]
         ]
 
         other_imgs = np.concatenate(other_imgs, 0)


### PR DESCRIPTION
imresize was deprecated in scipy 1.0 and removed in scipy 1.3. Failed to run therefore by default on Google Colab

Sorry for opening another pull request. I deleted my other forked repo and that kind of broke everything on github.