### PR TITLE
Issue #202 add flame life + bomb movement

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -49,4 +49,6 @@ It has the following format:
 * Enemies: A list of three Ints, each in [9, 13]. Which agents are this agent's enemies. There are three here to be amenable to all variants of the game. When there are only two enemies like in the team competitions, the last Int will be the AgentDummy to reflect the fact that there are only two enemies.
 * Bomb Blast Strength: An 11x11 numpy int array representing the bombs' blast strengths in the agent's view. Everything outside of its view will be fogged out.
 * Bomb Life: An 11x11 numpy int array representing the bombs' life in the agent's view. Everything outside of its view will be fogged out.
+* Bomb Movement Direction: An 11x11 numpy int array representing the bombs' movement direction (in terms of an agent's action space: 1 -> up, 2 -> down etc...) in the agent's view. Everything outside of its view will be fogged out.
+* Flame Life: An 11x11 numpy int array representing the flames' life in the agent's view. Everything outside of its view will be fogged out.
 * Message: (Team Radio only) A list of two Ints, each in [0, 8]. The message being relayed from the teammate. Both ints are zero when a teammate is dead or it's the first step. Otherwise they are in [1, 8].

--- a/pommerman/characters.py
+++ b/pommerman/characters.py
@@ -166,13 +166,13 @@ class Flame(object):
 
     def __init__(self, position, life=2):
         self.position = position
-        self._life = life
+        self.life = life
 
     def tick(self):
-        self._life -= 1
+        self.life -= 1
 
     def is_dead(self):
-        return self._life == 0
+        return self.life == 0
 
     def to_json(self):
-        return {"position": self.position, "life": self._life}
+        return {"position": self.position, "life": self.life}

--- a/pommerman/envs/v0.py
+++ b/pommerman/envs/v0.py
@@ -138,7 +138,7 @@ class Pomme(gym.Env):
 
     def get_observations(self):
         self.observations = self.model.get_observations(
-            self._board, self._agents, self._bombs,
+            self._board, self._agents, self._bombs, self._flames,
             self._is_partially_observable, self._agent_view_size,
             self._game_type, self._env)
         for obs in self.observations:


### PR DESCRIPTION
As requested in issue #202 adds further array to observation of an agent. `flame_life` ticks down like the bombs except it starts at 3.

EDIT: also added bomb movement direction in as further map of ints where bomb movement is int in action space

EDIT 2: when squashing commits `make_flame_map` function got copied twice. The second force push removed that error.

EDIT 3: the third force push were two spelling errors I found in the documentation. My bad!