### PR TITLE
Bugfix: Board is always copied when returned as an observation

### DIFF
--- a/pommerman/forward_model.py
+++ b/pommerman/forward_model.py
@@ -546,9 +546,8 @@ class ForwardModel(object):
         observations = []
         for agent in agents:
             agent_obs = {'alive': alive_agents}
-            board = curr_board
+            board = curr_board.copy()
             if is_partially_observable:
-                board = board.copy()
                 for row in range(board_size):
                     for col in range(board_size):
                         if not in_view_range(agent.position, row, col):


### PR DESCRIPTION
Previously this was only done if the state was partially observable. Therefore the fully-observed version led to in-place modifications of the observations when the state of the environment changed (board in state and board in next_state are would be the same)