### PR TITLE
add missing obs transform 'flame_life' in docker runner

### DIFF
--- a/pommerman/runner/docker_agent_runner.py
+++ b/pommerman/runner/docker_agent_runner.py
@@ -39,6 +39,7 @@ class DockerAgentRunner(metaclass=abc.ABCMeta):
             observation['bomb_life'] = np.array(observation['bomb_life'], dtype=np.float64)
             observation['bomb_blast_strength'] = np.array(observation['bomb_blast_strength'], dtype=np.float64)
             observation['bomb_moving_direction'] = np.array(observation['bomb_moving_direction'], dtype=np.float64)
+            observation['flame_life'] = np.array(observation['flame_life'], dtype=np.float64)
 
             action_space = data.get("action_space")
             action_space = json.loads(action_space)


### PR DESCRIPTION
Following #249, I oversaw another missing obs conversion in the docker runner for 'flame_life'. Cross-checking with the forward model `get_observations` there are no other observations that need to be handled.
Thanks for @cinjon for handling issues / PR's so quickly.