### PR TITLE
[draft] add missing 'import json' to v2 env

### DIFF
--- a/pommerman/envs/v2.py
+++ b/pommerman/envs/v2.py
@@ -7,6 +7,7 @@ observation stream for each agent.
 """
 from gym import spaces
 import numpy as np
+import json
 
 from .. import constants
 from .. import utility


### PR DESCRIPTION
The v2 environment uses the 'json' module in the `get_json_info` and `set_json_info` function, but the module is not imported. It leads to the error `NameError: name 'json' is not defined`.

This PR adds the missing import.